### PR TITLE
drop r-xml2 dep

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   merge_build_host: true  # [win]
-  number: 0
+  number: 1
   noarch: generic
   rpaths:
     - lib/R/lib/
@@ -29,14 +29,12 @@ requirements:
     - r-htmltools
     - r-magrittr
     - r-officer
-    - r-xml2
     - r-yaml
   run:
     - r-base
     - r-htmltools
     - r-magrittr
     - r-officer
-    - r-xml2
     - r-yaml
 
 test:


### PR DESCRIPTION
As of v0.1.3, the `r-xml2` dependency is unnecessary.

# Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
